### PR TITLE
Better regex delimiter when matching URIs

### DIFF
--- a/ironcache/ext.ironcache.php
+++ b/ironcache/ext.ironcache.php
@@ -269,7 +269,7 @@ class Ironcache_ext
 				}
 			}
 			
-			elseif(preg_match('/' . $t[0] . '/', $this->uri))
+			elseif(preg_match('#' . $t[0] . '#', $this->uri))
 			{
 				$this->cacheable = true;
 			}


### PR DESCRIPTION
I altered the preg_match pattern to use '#' as the regex delimiter rather than '/' since slashes will appear in the config all the time, and # won't. This way it's not necessary to escape every slash in the config.

That said, it introduces a soft-breaking change to existing configs with escaped slashes, since '\/' will now match literally.
